### PR TITLE
Added visualiztion of server errors on frontend

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,3 +1,24 @@
 <template>
+  <div>
+    <h1 class="text-red-500 text-4xl" v-if="this.userStore.errormsg !== 'nothing'">
+      {{ "ERROR from server: " + "(" + this.userStore.errormsg + ")" }}
+    </h1>
+  </div>
   <router-view />
 </template>
+
+
+<script>
+import { mapStores } from "pinia";
+import { useUserStore } from "./stores/user";
+export default {
+  name: "App",
+  computed: {
+    ...mapStores(useUserStore),
+  },
+  components: {
+  },
+  methods: {
+  },
+};
+</script>

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -9,6 +9,7 @@ export const useUserStore = defineStore("user", {
       username: "anonimous",
       password: "anonimous",
       port: "8080",
+      errormsg: 'nothing',
 
     };
   },

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -140,6 +140,7 @@ export default {
       type 1 == normal message 
       type 2 == message indicating username
       type 3 == message from server broadcasting available users
+      type 4 == message from server indicating error
       */
       switch (data.type) {
         case 1:
@@ -189,7 +190,13 @@ export default {
             data.allusers.includes(value.username)
           );
           this.chats = filtered;
+          break;
+        case 4: // message from server
+          console.log("received ERROR message from server");
+          this.userStore.errormsg = data.content;
+          break;
       }
+
     },
     getDateTime: function () {
       const today = new Date();


### PR DESCRIPTION
Added a Simple tag that is central in the website (does not belong to the any router view) that shows server errors that arrive via web-socket messages with type = 4.

Solves the frontend side of feature request  luque667788/chatapp-backend#4 